### PR TITLE
301971 remove all calls to logyard from logyard apps lgr

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -1,13 +1,14 @@
 package server
 
 import (
-	"confdis/go/confdis"
 	"fmt"
-	"github.com/ActiveState/log"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/ActiveState/confdis/go/confdis"
+	"github.com/ActiveState/log"
 )
 
 // Config refers to Stackato configuration under a specific


### PR DESCRIPTION
Updated the import path to non-relative path. This fix is required if we are migrating logyard-apps-lgr to use godep.
